### PR TITLE
Update script to use new `normalizekeys=1` functionality

### DIFF
--- a/webpagetest.gs
+++ b/webpagetest.gs
@@ -171,7 +171,7 @@ function getResults() {
         if (url && status < 200) {
             
             // WebPageTest
-            var wptAPI = url + "?f=json";
+            var wptAPI = url + "?f=json&normalizekeys=1";
             
             var response = UrlFetchApp.fetch(wptAPI);
             var result = JSON.parse(response.getContentText());


### PR DESCRIPTION
New functionality added to WPT to strip out non-alphanumeric characters from the API key names using the `normalizekeys=1` URL parameter. This doesn't effect any of the default metrics in the example sheet.

I've verified this works on the public instance of WPT:

After change but before the result field key names were updated. No results for some columns as the key names have now changed to not include non-alphanumeric characters:

![Screenshot 2020-10-10 at 00 30 42](https://user-images.githubusercontent.com/1223960/95639601-f6f8c900-0a90-11eb-950e-419009226abb.png)

After updating the field key names to remove the non-alphanumeric characters in the keys:

![Screenshot 2020-10-10 at 00 31 11](https://user-images.githubusercontent.com/1223960/95639675-49d28080-0a91-11eb-9f2b-e82437b5a511.png)
